### PR TITLE
Added get_log_representation note for docs

### DIFF
--- a/pm4py/objects/log/util/get_log_representation.py
+++ b/pm4py/objects/log/util/get_log_representation.py
@@ -331,6 +331,8 @@ def get_representation(log, str_tr_attr, str_ev_attr, num_tr_attr, num_ev_attr, 
     """
     Get a representation of the event log that is suited for the data part of the decision tree learning
 
+    NOTE: this function only encodes the last value seen for each attribute
+
     Parameters
     -------------
     log


### PR DESCRIPTION
Since function get_log_representation in pm4py/objects/log/util encodes only the last value seen for each attribute in the entire trace, I added a note for the documentation saying it, so that others know.

Best,
lsabi