### PR TITLE
PNML importer misses an import

### DIFF
--- a/pm4py/objects/petri/importer/__init__.py
+++ b/pm4py/objects/petri/importer/__init__.py
@@ -1,1 +1,1 @@
-from pm4py.objects.petri.importer import versions, factory
+from pm4py.objects.petri.importer import versions, factory, pnml


### PR DESCRIPTION
Hello, 
The pnml importer doesn't work without this import. 
Thanks, 
Mathilde 