### PR TITLE
Bug fix pretty print

### DIFF
--- a/examples/alignment_test.py
+++ b/examples/alignment_test.py
@@ -7,7 +7,6 @@ from pm4py.algo.conformance.alignments.versions.state_equation_a_star import PAR
 from pm4py.algo.conformance.alignments.versions.state_equation_a_star import PARAM_TRACE_COST_FUNCTION
 from pm4py.objects import log as log_lib
 from pm4py.objects.log.importer.xes import factory as xes_importer
-from pm4py.objects.conversion.log import factory as log_conv
 from pm4py.objects.petri.importer.pnml import import_net
 from pm4py.algo.conformance.alignments.utils import pretty_print_alignments
 
@@ -31,7 +30,6 @@ def execute_script():
     # pnml_path = 'C:/Users/bas/Documents/tue/svn/private/logs/a32_logs/a32.pnml'
 
     log = xes_importer.import_log(log_path)
-    log = log_conv.apply(log, parameters=None, variant=log_conv.TO_EVENT_STREAM)
     net, marking, fmarking = import_net(pnml_path)
 
     model_cost_function = dict()

--- a/pm4py/algo/conformance/alignments/utils.py
+++ b/pm4py/algo/conformance/alignments/utils.py
@@ -38,8 +38,11 @@ def pretty_print_alignments(alignments):
     :param alignment: <class 'list'>
     :return: Nothing
     """
-    for alignment in alignments:
-        __print_single_alignment(alignment["alignment"])
+    if isinstance(alignments, list):
+        for alignment in alignments:
+            __print_single_alignment(alignment["alignment"])
+    else:
+        __print_single_alignment(alignments["alignment"])
 
 
 def __print_single_alignment(step_list):


### PR DESCRIPTION
pretty print now works for alignment dicts and list of alignment dicts,
removed unnecessary log conversion into an event stream from the alignment example