### PR TITLE
Add export sublog

### DIFF
--- a/pm4py/algo/conformance/alignments/versions/state_equation_a_star.py
+++ b/pm4py/algo/conformance/alignments/versions/state_equation_a_star.py
@@ -73,7 +73,8 @@ def get_best_worst_cost(petri_net, initial_marking, final_marking, parameters=No
     """
     trace = log_implementation.Trace()
     new_parameters = copy(parameters)
-    if PARAM_TRACE_COST_FUNCTION not in new_parameters or len(new_parameters[PARAM_TRACE_COST_FUNCTION]) < len(trace):
+    if new_parameters and (PARAM_TRACE_COST_FUNCTION not in new_parameters
+                           or len(new_parameters[PARAM_TRACE_COST_FUNCTION]) < len(trace)):
         new_parameters[PARAM_TRACE_COST_FUNCTION] = list(
             map(lambda e: utils.STD_MODEL_LOG_MOVE_COST, trace))
 

--- a/pm4py/objects/log/exporter/xes/factory.py
+++ b/pm4py/objects/log/exporter/xes/factory.py
@@ -49,7 +49,6 @@ def export_log(log, output_file_path, variant="etree", parameters=None):
     if "compress" in parameters and parameters["compress"]:
         compression.compress(output_file_path)
 
-
 def apply(log, output_file_path, variant="etree", parameters=None):
     """
     Factory method to export a XES from a log
@@ -65,5 +64,6 @@ def apply(log, output_file_path, variant="etree", parameters=None):
     parameters
         Parameters of the algorithm:
             compress -> Indicates that the XES file must be compressed
+            sublog_size (int) -> Indicates that the XES will contain only the x first traces
     """
     export_log(log, output_file_path, variant=variant, parameters=parameters)

--- a/pm4py/objects/log/exporter/xes/factory.py
+++ b/pm4py/objects/log/exporter/xes/factory.py
@@ -65,5 +65,6 @@ def apply(log, output_file_path, variant="etree", parameters=None):
         Parameters of the algorithm:
             compress -> Indicates that the XES file must be compressed
             sublog_size (int) -> Indicates that the XES will contain only the x first traces
+            random_sublog (bool) -> When a sublog is chosen, one may want to get random traces, false by default
     """
     export_log(log, output_file_path, variant=variant, parameters=parameters)

--- a/pm4py/objects/log/exporter/xes/versions/etree_xes_exp.py
+++ b/pm4py/objects/log/exporter/xes/versions/etree_xes_exp.py
@@ -260,6 +260,8 @@ def export_log_as_string(log, parameters=None):
         PM4PY log
     parameters
         Parameters of the algorithm
+            sublog_size (int) -> Indicates that the XES will contain only the x first traces
+            random_sublog (bool) -> When a sublog is chosen, one may want to get random traces, false by default
 
     Returns
     -----------
@@ -268,7 +270,12 @@ def export_log_as_string(log, parameters=None):
     """
     if parameters is None:
         parameters = {}
+    if "sublog_size" in parameters :
+        log.reduceList(parameters["sublog_size"])
+    if "sublog_size" in parameters and "random_sublog" in parameters:
+        log.reduceList(parameters["sublog_size"],parameters["random_sublog"])
     del parameters
+
 
     # Gets the XML tree to export
     tree = export_log_tree(log)
@@ -288,10 +295,15 @@ def export_log(log, output_file_path, parameters=None):
         Output file path
     parameters
         Parameters of the algorithm
-
+            sublog_size (int) -> Indicates that the XES will contain only the x first traces
+            random_sublog (bool) -> When a sublog is chosen, one may want to get random traces, false by default
     """
     if parameters is None:
         parameters = {}
+    if "sublog_size" in parameters :
+        log.reduceList(parameters["sublog_size"])
+    if "sublog_size" in parameters and "random_sublog" in parameters:
+        log.reduceList(parameters["sublog_size"],parameters["random_sublog"])
     del parameters
 
     # Gets the XML tree to export

--- a/pm4py/objects/log/log.py
+++ b/pm4py/objects/log/log.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, Sequence
-
+from random import sample
 
 class Event(Mapping):
     def __init__(self, *args, **kw):
@@ -54,6 +54,12 @@ class EventStream(Sequence):
 
     def index(self, x, start: int = ..., end: int = ...):
         return self._list.index(x, start, end)
+
+    def reduceList(self, length, random=False):
+        if random :
+            self._list=sample(self._list,length)
+        else :
+            self._list=self._list[:length]
 
     def count(self, x):
         return self._list.count(x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 pyvis
 networkx>=2.4
-matplotlib
+matplotlib<=3.0
 numpy
 ciso8601
 lxml

--- a/tests/csv_impexp_test.py
+++ b/tests/csv_impexp_test.py
@@ -29,6 +29,27 @@ class CsvImportExportTest(unittest.TestCase):
         self.assertEqual(len(log), len(log_imported_after_export))
         os.remove(os.path.join(OUTPUT_DATA_DIR, "running-example-exported.xes"))
 
+    def test_importExportCSVtosublogXES(self):
+        # to avoid static method warnings in tests,
+        # that by construction of the unittest package have to be expressed in such way
+        '''
+        Test to export only a sublog of a log
+        '''
+        self.dummy_variable = "dummy_value"
+        event_log = csv_importer.import_event_stream(os.path.join(INPUT_DATA_DIR, "running-example.csv"))
+        event_log = sorting.sort_timestamp(event_log)
+        event_log = sampling.sample(event_log)
+        event_log = index_attribute.insert_event_index_as_event_attribute(event_log)
+        log = log_conv_fact.apply(event_log)
+        log = sorting.sort_timestamp(log)
+        log = sampling.sample(log)
+        log = index_attribute.insert_trace_index_as_event_attribute(log)
+        xes_exporter.export_log(log, os.path.join(OUTPUT_DATA_DIR, "smaller-running-example-exported.xes"),parameters={"sublog_size":1})
+        log_imported_after_export = xes_importer.import_log(
+            os.path.join(OUTPUT_DATA_DIR, "smaller-running-example-exported.xes"))
+        self.assertEqual(1, len(log_imported_after_export))
+        os.remove(os.path.join(OUTPUT_DATA_DIR, "smaller-running-example-exported.xes"))
+
     def test_importExportCSVtoCSV(self):
         # to avoid static method warnings in tests,
         # that by construction of the unittest package have to be expressed in such way


### PR DESCRIPTION
Hello,
I needed to export only a sublog and I didn't find a feature for this. I created a function to get either $n traces randomly either the $n first traces directly in the EventStream Object. Then, in the export xes, one will find two new parameters. I added a very quick unittest. 
Take care, 
BoltMaud

